### PR TITLE
ignore empty lines in nix build output

### DIFF
--- a/nix/direnv-nix-lorelei.nix
+++ b/nix/direnv-nix-lorelei.nix
@@ -422,7 +422,7 @@ _nixgc_capture_autowatchable()
         # find paths and substitute them for the line
         s/\(copied source\|evaluating file\|trace: lorri read:\)[^']*'\([^']\+\)'.*/\2/;
         # delete /nix/store paths and lines with no found paths
-        /\(^\/nix\/\|^[^\/]\)/d;
+        /^\(\/nix\/\|[^\/]\|$\)/d;
         # print paths found not in /nix/store
         p
     " | {


### PR DESCRIPTION
Previously, empty lines were parsed as files to watch, leading to error
```
  `Error: Could not open '': No such file or directory.`
```
when `_nixgc_record_hashes` was called.

#### Reproduce
```
tmpDir=/tmp/lorelei-bug
rm -rf $tmpDir
mkdir -p $tmpDir

# Set this to the direnv-nix-lorelei src
lorelei=$(nix-build --no-out-link /path/to/src -A direnv-nix-lorelei)

cat > $tmpDir/.envrc <<EOF
. $lorelei/share/direnv-nix-lorelei/nix-lorelei.sh
use_nix_gcrooted -a
EOF

cat > $tmpDir/shell.nix <<EOF
(import <nixpkgs> {}).mkShell {
  shellHook = ''
    # force rebuild: $(date)
    # print empty line
    echo
  '';
}
EOF

(cd $tmpDir; direnv allow; direnv exec . true)
rm -rf $tmpDir
```

Output
```
direnv: loading /tmp/lorelei-bug/.envrc
direnv: not modified: /home/main/.cache/direnv-layouts/@tmp@lorelei-bug/delete_to_rebuild
direnv: hash check invalidated cache
direnv: rebuilding with Nix
Error: Could not open '': No such file or directory.
direnv: watching /home/main/.cache/direnv-layouts/@tmp@lorelei-bug/delete_to_rebuild
direnv: watching .envrc
direnv: watching /home/main/.config/nixpkgs/config.nix
direnv: watching /tmp/lorelei-bug/shell.nix
```