### PR TITLE
Add home-manager module

### DIFF
--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -1,0 +1,30 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.programs.direnv-nix-lorelei;
+in
+{
+  options = {
+    programs.direnv-nix-lorelei = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        defaultText = "false";
+        description = ''
+          Whether to enable direnv-nix-lorelei.
+        '';
+      };
+      package = mkOption {
+        type = types.package;
+        default = (import ./default.nix).direnv-nix-lorelei;
+        description = ''
+          The <literal>direnv-nix-lorelei</literal> package to use.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    xdg.configFile."direnv/lib/direnv-nix-lorelei.sh".source = "${cfg.package}/share/direnv-nix-lorelei/nix-lorelei.sh";
+  };
+}


### PR DESCRIPTION
I created a simple home-manager module that lets you configure direnv-nix-lorelei easily.

1. install home-manager: https://github.com/nix-community/home-manager#installation
2. Add my version of direnv-nix-lorelei to nix-channel

```
nix-channel --add https://github.com/vroad/direnv-nix-lorelei/archive/home-manager.tar.gz direnv-nix-lorelei
nix-channel --update
```

3. edit home.nix like this.

```nix
{ config, pkgs, ... }:

{
  # direnv-nix-lorelei configurations
  imports = [
    "${<direnv-nix-lorelei>}/nix/home-manager-module.nix"
  ];
  programs.direnv.enable = true;
  programs.direnv-nix-lorelei.enable = false;

  # auto generated configurations
  programs.home-manager.enable = true;

  home.username = "myUserName";
  home.homeDirectory = "/home/myUserName";

  home.stateVersion = "21.05";
}

```